### PR TITLE
Implemented basic frontend for customer

### DIFF
--- a/uoftruck-front-end/src/components/customer/allTrucksPage.js
+++ b/uoftruck-front-end/src/components/customer/allTrucksPage.js
@@ -1,0 +1,29 @@
+import React from "react";
+import TruckPreview from "./elements/truckPreview";
+
+function allTrucksPage() {
+  //vendor token
+  //order data
+
+  return (
+    <div>
+      <h1>Trucks</h1>
+      <div className="d-inline-block">
+        <h5 className="m-auto text-muted text-center text-start p-1">
+          Trucks Near You
+        </h5>
+        <div>
+          {/* a map to all the items in this section */}
+          <TruckPreview />
+          <TruckPreview />
+          <TruckPreview />
+          <TruckPreview />
+          <TruckPreview />
+          <TruckPreview />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default allTrucksPage;

--- a/uoftruck-front-end/src/components/customer/elements/menuItem.js
+++ b/uoftruck-front-end/src/components/customer/elements/menuItem.js
@@ -1,0 +1,24 @@
+import React, { Component } from "react";
+
+class menuItem extends React.Component {
+  render() {
+    // get order data
+    return (
+      <div className="d-flex w-80 justify-content-center p-2 border border-dark rounded my-1">
+        {/* it should display menu item name based on the database */}
+        <h4 className="m-auto mx-4">{"menu item abc"}</h4>
+        <div className="btn-group">
+          {/* clicking on the buttons should update the order state, then reload the orders page */}
+          <button type="button" class="btn btn-sm btn-outline-danger">
+            Remove
+          </button>
+          <button type="button" class="btn btn-sm btn-outline-success">
+            Add
+          </button>
+        </div>
+      </div>
+    );
+  }
+}
+
+export default menuItem;

--- a/uoftruck-front-end/src/components/customer/elements/pastOrderPreview.js
+++ b/uoftruck-front-end/src/components/customer/elements/pastOrderPreview.js
@@ -1,0 +1,28 @@
+import React, { Component } from "react";
+
+class pastOrderPreview extends React.Component {
+  render() {
+    // get order data
+    return (
+      <div className="d-flex w-80 justify-content-center p-2 border border-dark rounded my-1">
+        {/* it should display orders based on data */}
+        <h4 className="m-auto mx-4">
+          {"Order from Truck X"}
+          <small>
+            <ul class="list-unstyled">
+              <li>2021-12-25</li>
+            </ul>
+          </small>
+        </h4>
+        <div className="btn-group">
+          {/* clicking on the buttons should show a detailed receipt */}
+          <button type="button" class="btn btn-sm btn-outline-primary">
+            View
+          </button>
+        </div>
+      </div>
+    );
+  }
+}
+
+export default pastOrderPreview;

--- a/uoftruck-front-end/src/components/customer/elements/truckPreview.js
+++ b/uoftruck-front-end/src/components/customer/elements/truckPreview.js
@@ -1,0 +1,28 @@
+import React, { Component } from "react";
+
+class truckPreview extends React.Component {
+  render() {
+    // get order data
+    return (
+      <div className="d-flex w-80 justify-content-center p-2 border border-dark rounded my-1">
+        {/* it should display truck names based on database */}
+        <h4 className="m-auto mx-4">
+          {"Epic Truck"}
+          <small>
+            <ul class="list-unstyled">
+              <li>Location</li>
+            </ul>
+          </small>
+        </h4>
+        <div className="btn-group">
+          {/* clicking on the buttons should update the order state, then reload the orders page */}
+          <button type="button" class="btn btn-sm btn-outline-primary">
+            View
+          </button>
+        </div>
+      </div>
+    );
+  }
+}
+
+export default truckPreview;

--- a/uoftruck-front-end/src/components/customer/menuPage.js
+++ b/uoftruck-front-end/src/components/customer/menuPage.js
@@ -1,0 +1,35 @@
+import React from "react";
+import MenuItem from "./elements/menuItem";
+
+function menuPage() {
+  //vendor token
+  //order data
+
+  return (
+    <div>
+      <h1>Menu</h1>
+      <div className="d-inline-block">
+        <h5 className="m-auto text-muted text-start p-1">Recommended</h5>
+        <div>
+          {/* a map to all the items in this section */}
+          <MenuItem />
+          <MenuItem />
+        </div>
+
+        <h5 className="m-auto text-muted text-start p-1">Full Menu</h5>
+        <div>
+          {/* a map to all the items in this section */}
+          <MenuItem />
+          <MenuItem />
+          <MenuItem />
+          <MenuItem />
+          <MenuItem />
+          <MenuItem />
+          <MenuItem />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default menuPage;

--- a/uoftruck-front-end/src/components/customer/orderHistoryPage.js
+++ b/uoftruck-front-end/src/components/customer/orderHistoryPage.js
@@ -1,0 +1,28 @@
+import React from "react";
+import PastOrderPreview from "./elements/pastOrderPreview";
+
+function orderHistoryPage() {
+  //vendor token
+  //order data
+
+  return (
+    <div>
+      <h1>Past Orders</h1>
+      <div className="d-inline-block">
+        <h5 className="m-auto text-muted text-start p-1">November 2021</h5>
+        <div>
+          {/* a map to all the pastOrderPreviews in this section */}
+          <PastOrderPreview />
+          <PastOrderPreview />
+          <PastOrderPreview />
+          <PastOrderPreview />
+          <PastOrderPreview />
+          <PastOrderPreview />
+          <PastOrderPreview />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default orderHistoryPage;

--- a/uoftruck-front-end/src/components/customer/singleTruckPage.js
+++ b/uoftruck-front-end/src/components/customer/singleTruckPage.js
@@ -1,0 +1,1 @@
+// TODO: do something with this, I don't know what would be displayed here


### PR DESCRIPTION
Implemented basic frontend for the customer UI, closely matching what was done with the Vendor UI. 
- allTrucksPage -> Page where customer would view all available foodtrucks and their locations, and have the option to click into their menus
- menuPage -> Basic page representing a menu with buttons for adding/removing items. Ideally this would interact with the cart but I'm not sure how that would work as of now.
- - orderHistoryPage -> Page where past customer orders are displayed to customers with prices and an option to view receipt. Receipt viewing functionality not implemented

Did not end up implementing singleTruckPage because I didn't know what would be put there. Originally I thought this page might be used to provide a description of the Truck, but I felt that this would be redundant since it makes more sense to me that people would want to click directly into the menu anyways.